### PR TITLE
Add "Duplicate effect and copy fields" button

### DIFF
--- a/editor/UserInterface/Components/EffectConfigUi.cs
+++ b/editor/UserInterface/Components/EffectConfigUi.cs
@@ -290,7 +290,7 @@ namespace StorybrewEditor.UserInterface.Components
                 effect.Refresh();
         }
 
-        private void copyConfiguration()
+        public void copyConfiguration()
         {
             using (var stream = new MemoryStream())
             using (var writer = new BinaryWriter(stream))
@@ -305,7 +305,7 @@ namespace StorybrewEditor.UserInterface.Components
             }
         }
 
-        private void pasteConfiguration()
+        public void pasteConfiguration()
         {
             var changed = false;
             try

--- a/editor/UserInterface/Components/EffectList.cs
+++ b/editor/UserInterface/Components/EffectList.cs
@@ -111,7 +111,7 @@ namespace StorybrewEditor.UserInterface.Components
             {
                 Widget effectRoot;
                 Label nameLabel;
-                Button renameButton, statusButton, configButton, editButton, removeButton;
+                Button renameButton, statusButton, configButton, editButton, removeButton, copyDownButton;
                 effectsLayout.Add(effectRoot = new LinearLayout(Manager)
                 {
                     AnchorFrom = BoxAlignment.Centre,
@@ -164,6 +164,15 @@ namespace StorybrewEditor.UserInterface.Components
                             StyleName = "icon",
                             Icon = IconFont.Gear,
                             Tooltip = "Configure",
+                            AnchorFrom = BoxAlignment.Centre,
+                            AnchorTo = BoxAlignment.Centre,
+                            CanGrow = false,
+                        },
+                        copyDownButton = new Button(Manager)
+                        {
+                            StyleName = "icon",
+                            Icon = IconFont.Copy,
+                            Tooltip = "Duplicate effect and copy fields",
                             AnchorFrom = BoxAlignment.Centre,
                             AnchorTo = BoxAlignment.Centre,
                             CanGrow = false,
@@ -232,10 +241,30 @@ namespace StorybrewEditor.UserInterface.Components
                     }
                     else effectConfigUi.Displayed = false;
                 };
+                copyDownButton.OnClick += (sender, e) =>
+                {
+                    Effect copiedEffect = ef;
+                    Manager.ScreenLayerManager.ShowPrompt("Name of duplicated effect", $"Change name for {ef.Name}", ef.Name, (newName) =>
+                    {
+                        effectConfigUi.Effect = ef;
+                        effectConfigUi.copyConfiguration();
+                        copiedEffect = project.AddEffect(ef.BaseName);
+                        effectConfigUi.Effect = copiedEffect;
+                        effectConfigUi.Displayed = true;
+                        copiedEffect.Name = newName;
+                        refreshEffects();
+                        pasteConfigAfterCopy(copiedEffect);
+                    });
+                };
                 removeButton.OnClick += (sender, e) => Manager.ScreenLayerManager.ShowMessage($"Remove {ef.Name}?", () => project.Remove(ef), true);
             }
         }
-
+        private void pasteConfigAfterCopy(Effect effect)
+        {
+            effectConfigUi.Effect = effect;
+            effectConfigUi.pasteConfiguration();
+            Manager.ScreenLayerManager.ShowMessage($"WHY");
+        }
         private static void updateStatusButton(Button button, Effect effect)
         {
             button.Disabled = string.IsNullOrWhiteSpace(effect.StatusMessage);


### PR DESCRIPTION
Adds a button in the effects menu to duplicate an effect and copy its fields to save time when you want to make a copy of an effect.